### PR TITLE
NodeInspectorPanel shows by default but can be turned-off by option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ yarn start-prod
 
 Neo4j Browser has both unit and end to end tests running automatically on every pull request. To run the tests locally:
 
-`yarn test-unit` runs a linter and then our unit tests.
+`yarn jest` runs our unit tests.
 
 `yarn test-e2e` runs our Cypress end to end tests in the easiest, slowest way. Running them with this command requires docker installed and that nothing else runs on ports 7687 and 8080.
 

--- a/docs/modules/ROOT/pages/neo4j-arc/index.adoc
+++ b/docs/modules/ROOT/pages/neo4j-arc/index.adoc
@@ -80,6 +80,23 @@ export default function MyGraphComponent(): JSX.Element {
 
 image:basic-example.png[width=900]
 
+=== Options
+
+==== Turnning Off Inspection Panel
+
+[source,typescript]
+----
+export default function MyGraphComponent(): JSX.Element {
+
+  return (
+    <GraphVisualizer
+      ...
+      showNodeInspectorPanel={false}
+    />
+  );
+}
+----
+
 = Neo4J Browser Internals
 
 The Neo4J Browser is logically composed of 2 parts:

--- a/docs/modules/ROOT/pages/neo4j-arc/index.adoc
+++ b/docs/modules/ROOT/pages/neo4j-arc/index.adoc
@@ -21,16 +21,6 @@ import { BasicNode, BasicRelationship, GraphVisualizer } from "neo4j-devtools-ar
 
 export default function MyGraphComponent(): JSX.Element {
 
-  const isFullscreen = true;
-  const graphData = selectGraphData();
-
-  const [hasVis, setHasVis] = useState<boolean>(true);
-  const [visElement, setVisElement] = useState<null | {
-    svgElement: unknown;
-    graphElement: unknown;
-    type: "plan" | "graph";
-  }>(null); 
-
   const nodes: BasicNode[] = [
     {
       id: "1",
@@ -67,6 +57,8 @@ export default function MyGraphComponent(): JSX.Element {
     }
   ]
 
+  const isFullscreen = true;
+
   return (
     <GraphVisualizer
       maxNeighbours={100}
@@ -75,10 +67,6 @@ export default function MyGraphComponent(): JSX.Element {
       autocompleteRelationships={false}
       relationships={links}
       isFullscreen={isFullscreen}
-      assignVisElement={(svgElement: any, graphElement: any) => {
-        setVisElement({ svgElement, graphElement, type: "graph" });
-        setHasVis(true);
-      }}
       nodeLimitHit={false}
       getAutoCompleteCallback={undefined}
       wheelZoomRequiresModKey={!isFullscreen}

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.test.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.test.tsx
@@ -64,12 +64,32 @@ describe('<GraphVisualizer />', () => {
   const renderComponent = ({
     showNodeInspectorPanel = true
   }: RenderComponentProps) => {
+    if (showNodeInspectorPanel) {
+      // we never pass showNodeInspectorPanel in this case to test the "default behavior"
+      return render(
+        <GraphVisualizer
+          maxNeighbours={100}
+          hasTruncatedFields={false}
+          nodes={nodes}
+          autocompleteRelationships={true} // "true" prevents "undefined (reading 'baseVal')" test error
+          relationships={links}
+          isFullscreen={isFullscreen}
+          nodeLimitHit={false}
+          getAutoCompleteCallback={undefined}
+          wheelZoomRequiresModKey={!isFullscreen}
+          wheelZoomInfoMessageEnabled={false}
+          useGeneratedDefaultColors={false}
+          initialZoomToFit={false}
+        />
+      )
+    }
+
     return render(
       <GraphVisualizer
         maxNeighbours={100}
         hasTruncatedFields={false}
         nodes={nodes}
-        autocompleteRelationships={false}
+        autocompleteRelationships={true}
         relationships={links}
         isFullscreen={isFullscreen}
         nodeLimitHit={false}
@@ -77,7 +97,8 @@ describe('<GraphVisualizer />', () => {
         wheelZoomRequiresModKey={!isFullscreen}
         wheelZoomInfoMessageEnabled={false}
         useGeneratedDefaultColors={false}
-        initialZoomToFit={true}
+        initialZoomToFit={false}
+        showNodeInspectorPanel={false}
       />
     )
   }
@@ -96,9 +117,9 @@ describe('<GraphVisualizer />', () => {
     renderComponent({ showNodeInspectorPanel: false })
 
     expect(
-      screen.getByRole('button', {
+      screen.queryByRole('button', {
         name: 'Collapse the node properties display'
       })
-    ).not.toBeInTheDocument()
+    ).toBeNull()
   })
 })

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.test.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Jiaqi Liu
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { BasicNode, BasicRelationship } from 'neo4j-arc/common'
+import { GraphVisualizer } from 'neo4j-arc/graph-visualization'
+
+describe('<GraphVisualizer />', () => {
+  const isFullscreen = true
+  const nodes: BasicNode[] = [
+    {
+      id: '1',
+      labels: ['Person'],
+      properties: {
+        name: 'Jack',
+        age: '20'
+      },
+      propertyTypes: {
+        name: 'string',
+        age: 'number'
+      }
+    },
+    {
+      id: '2',
+      labels: ['React'],
+      properties: {
+        name: 'ReactJS'
+      },
+      propertyTypes: {
+        name: 'string'
+      }
+    }
+  ]
+  const links: BasicRelationship[] = [
+    {
+      id: '3',
+      startNodeId: '1',
+      endNodeId: '2',
+      type: 'likes',
+      properties: {},
+      propertyTypes: {}
+    }
+  ]
+
+  type RenderComponentProps = {
+    showNodeInspectorPanel?: boolean
+  }
+
+  const renderComponent = ({
+    showNodeInspectorPanel = true
+  }: RenderComponentProps) => {
+    return render(
+      <GraphVisualizer
+        maxNeighbours={100}
+        hasTruncatedFields={false}
+        nodes={nodes}
+        autocompleteRelationships={false}
+        relationships={links}
+        isFullscreen={isFullscreen}
+        nodeLimitHit={false}
+        getAutoCompleteCallback={undefined}
+        wheelZoomRequiresModKey={!isFullscreen}
+        wheelZoomInfoMessageEnabled={false}
+        useGeneratedDefaultColors={false}
+        initialZoomToFit={true}
+      />
+    )
+  }
+
+  test('should render NodeInspectorPanel by default', async () => {
+    renderComponent({})
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Collapse the node properties display'
+      })
+    ).toBeInTheDocument()
+  })
+
+  test('should not render NodeInspectorPanel if explicitly being turned off', async () => {
+    renderComponent({ showNodeInspectorPanel: false })
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Collapse the node properties display'
+      })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.tsx
@@ -56,6 +56,7 @@ type GraphVisualizerDefaultProps = {
   initialZoomToFit?: boolean
   disableWheelZoomInfoMessage: () => void
   useGeneratedDefaultColors: boolean
+  showNodeInspectorPanel: boolean
 }
 type GraphVisualizerProps = GraphVisualizerDefaultProps & {
   relationships: BasicRelationship[]
@@ -118,7 +119,8 @@ export class GraphVisualizer extends Component<
     setNodePropertiesExpandedByDefault: () => undefined,
     wheelZoomInfoMessageEnabled: false,
     disableWheelZoomInfoMessage: () => undefined,
-    useGeneratedDefaultColors: true
+    useGeneratedDefaultColors: true,
+    showNodeInspectorPanel: true
   }
 
   constructor(props: GraphVisualizerProps) {
@@ -285,28 +287,30 @@ export class GraphVisualizer extends Component<
           initialZoomToFit={this.props.initialZoomToFit}
           onGraphInteraction={this.props.onGraphInteraction}
         />
-        <NodeInspectorPanel
-          graphStyle={graphStyle}
-          hasTruncatedFields={this.props.hasTruncatedFields}
-          hoveredItem={this.state.hoveredItem}
-          selectedItem={this.state.selectedItem}
-          stats={this.state.stats}
-          width={this.state.width}
-          setWidth={(width: number) =>
-            this.setState({ width: Math.max(panelMinWidth, width) })
-          }
-          expanded={this.state.nodePropertiesExpanded}
-          toggleExpanded={() => {
-            const { nodePropertiesExpanded } = this.state
-            this.props.setNodePropertiesExpandedByDefault(
-              !nodePropertiesExpanded
-            )
-            this.setState({ nodePropertiesExpanded: !nodePropertiesExpanded })
-          }}
-          DetailsPaneOverride={this.props.DetailsPaneOverride}
-          OverviewPaneOverride={this.props.OverviewPaneOverride}
-          onGraphInteraction={this.props.onGraphInteraction}
-        />
+        {this.props.showNodeInspectorPanel && (
+          <NodeInspectorPanel
+            graphStyle={graphStyle}
+            hasTruncatedFields={this.props.hasTruncatedFields}
+            hoveredItem={this.state.hoveredItem}
+            selectedItem={this.state.selectedItem}
+            stats={this.state.stats}
+            width={this.state.width}
+            setWidth={(width: number) =>
+              this.setState({ width: Math.max(panelMinWidth, width) })
+            }
+            expanded={this.state.nodePropertiesExpanded}
+            toggleExpanded={() => {
+              const { nodePropertiesExpanded } = this.state
+              this.props.setNodePropertiesExpandedByDefault(
+                !nodePropertiesExpanded
+              )
+              this.setState({ nodePropertiesExpanded: !nodePropertiesExpanded })
+            }}
+            DetailsPaneOverride={this.props.DetailsPaneOverride}
+            OverviewPaneOverride={this.props.OverviewPaneOverride}
+            onGraphInteraction={this.props.onGraphInteraction}
+          />
+        )}
       </StyledFullSizeContainer>
     )
   }

--- a/src/neo4j-arc/package.json
+++ b/src/neo4j-arc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-devtools-arc",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "main": "dist/neo4j-arc.js",
   "author": "Neo4j Inc.",
   "license": "GPL-3.0",


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

Changelog
---------

### Added

- neo4j-arc shows graph with an accompanying inspection panel on the right side. This panel might be not needed in at least 2 business scenarios:

  - a simple static page that just needs to show some static and simple graph
  - a MVP product has planned but would not want to add panel feature at the moment

  Thus, the panel still shows by default to preserve the upstream behavior; but a `defaultProps.showNodeInspectorPanel` to `GraphVisualizer`. `showNodeInspectorPanel` defaults to `true` if left unspecified in which case the inspection panel shows as before. When `showNodeInspectorPanel` is set to `false`, however, the panel doesn't show

### Changed

### Deprecated

### Removed

### Fixed

- Fixed out-dated README on running unit tests

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
* [x] (neo4j-arc) Manually bump version

Reference
---------

- [Find by aria-label](https://testing-library.com/docs/queries/byrole/#:~:text=For%20example%20%3Cimg%20aria%2Dlabel%3D%22fancy%20image%22%20src%3D%22fancy.jpg%22%20/%3E%20will%20be%20returned%20for%20getByRole(%27img%27%2C%20%7B%20name%3A%20%27fancy%20image%27%20%7D))
- [How do you test for the non-existence of an element using jest and react-testing-library?](https://stackoverflow.com/a/74387094) (same with [doc here](https://qubitpi.github.io/testing-library-docs/docs/queries/about#:~:text=Summary%20Table-,Type%20of%20Query,Yes,-Priority%E2%80%8B))