### PR TITLE
On-canvas node creation is done by sending message only

### DIFF
--- a/docs/modules/ROOT/pages/neo4j-arc/graph-interactions.adoc
+++ b/docs/modules/ROOT/pages/neo4j-arc/graph-interactions.adoc
@@ -1,10 +1,9 @@
 :description: How graph interations take effect on displayed graph and backing database
 
-
 [[user-interactions]]
 = How Graph Interations Take Effect on Displayed Graph and Backing Database
 
-We define *graph interactions* as any https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent[mouse] and
+We define *graph interactions* as any https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent[mouse] or
 https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent[keyboard] events on the
 link:../../visual-tour/index.html#frame-views[_Graph_ frame view]
 
@@ -40,23 +39,18 @@ click on canvas. We will follow the steps above by first defining the event hand
 [source,typescript]
 ----
   onCanvasDblClicked(): void {
-    this.graph.addNodes([ new NodeModel(...) ])
-    this.visualization.update({ updateNodes: true, updateRelationships: true })
-    this.graphModelChanged()
-
     this.onGraphInteraction(NODE_ON_CANVAS_CREATE, { name: 'New Node', labels: ['Undefined'] })
   }
 ----
 
 [NOTE] 
 ==== 
+When we add a new node to the graph, we do not update the visual of the graph on current canvas, because this update
+process involves lots of organic parts and taking care all of them is error-prone
 
-When we add a new node to the graph, it is important to update the visual of the graph using `visualization.update()`
-and the stats panel with `graphModelChanged()`
-
-We would also like to persist the new node to database so that refreshing the page or re-login shall still render this
-node. Therefore we invoke `onGraphInteraction()` above. The details of this method will be disucssed below 
-
+In stead, we persist the new node to database first (by invoking `onGraphInteraction()` above. The details of this
+method will be disucssed below) and later we trigger a new frame so all the refreshed data will be put onto a new
+canvas, including the new node. 
 ====
 
 Next, we bind the function so that `Visualization.ts` component can delegte any canvas double click callbacks to this
@@ -95,6 +89,14 @@ As we've mentioned earlier, we would like to persist this new node to database. 
 
 [source,typescript]
 ----
+import {
+  commandSources,
+  executeCommand
+} from 'shared/modules/commands/commandsDuck'
+
+...
+
+
   onGraphInteraction: GraphInteractionCallBack = (event, properties) => {
     if (event == NODE_ON_CANVAS_CREATE) {
       if (properties == null) {
@@ -122,8 +124,18 @@ As we've mentioned earlier, we would like to persist this new node to database. 
           }
         }
       )
+
+      const cmd = 'MATCH (n) RETURN n;'
+      const action = executeCommand(cmd, { source: commandSources.rerunFrame })
+      this.props.bus.send(action.type, action)
     }
   }
 ----
 
-The complete implementation is in https://github.com/QubitPi/neo4j-browser/pull/7[this PR] as a reference
+[NOTE] 
+==== 
+We trigger the aforementioned new fram using the last 3 lines above 
+====
+
+The complete implementation is in https://github.com/QubitPi/neo4j-browser/pull/7[this PR] and
+https://github.com/QubitPi/neo4j-browser/pull/26[this PR (optimization)] as references

--- a/e2e_tests/integration/viz.spec.ts
+++ b/e2e_tests/integration/viz.spec.ts
@@ -244,7 +244,7 @@ describe('Viz rendering', () => {
     cy.get(`[aria-label="zoom-out"]`).should('be.disabled')
   })
 
-  it('can create a new node by double clicking the canvas', () => {
+  it('can create a new node by double clicking the canvas and the new node has "description" and "name" property fields', () => {
     cy.executeCommand(':clear')
     cy.executeCommand(`CREATE (a:TestLabel {name: 'testNode'}) RETURN a`, {
       parseSpecialCharSequences: false
@@ -253,32 +253,22 @@ describe('Viz rendering', () => {
     cy.get('[data-testid="graphCanvas"]')
       .trigger('click', 200, 200, { force: true })
       .trigger('dblclick', 200, 200, { force: true })
-
-    cy.get('[data-testid="nodeGroups"]', { timeout: 5000 }).contains('New Node')
-    cy.get('[data-testid="vizInspector"]', { timeout: 5000 }).contains(
-      'Undefined'
-    )
-
-    cy.executeCommand('MATCH (n) DETACH DELETE n')
-  })
-
-  it('new node by double-clicking the canvas has "description" and "name" property fields', () => {
-    cy.executeCommand(':clear')
-    cy.executeCommand(`CREATE (a:TestLabel {name: 'testNode'}) RETURN a`, {
-      parseSpecialCharSequences: false
-    })
-
-    cy.get('[data-testid="graphCanvas"]')
-      .trigger('click', 200, 200, { force: true })
-      .trigger('dblclick', 200, 200, { force: true })
-
-    cy.get('[data-testid="nodeGroups"]', { timeout: 5000 })
+      .executeCommand(
+        `MATCH (n:TestLabel {name: "testNode"}) DETACH DELETE n`,
+        { parseSpecialCharSequences: false }
+      )
+      .executeCommand(`MATCH (n) RETURN n`, {
+        parseSpecialCharSequences: false
+      })
+      .get('[data-testid="nodeGroups"]', { timeout: 10000 })
       .contains('New Node')
       .trigger('mouseover', { force: true })
       .trigger('mouseenter', { force: true })
       .get('[data-testid="viz-details-pane-properties-table"]')
       .find('td:nth-child(1)')
       .should('have.text', '<elementId><id>descriptionname')
+      .get('[data-testid="vizInspector"]', { timeout: 5000 })
+      .contains('Undefined')
 
     cy.executeCommand('MATCH (n) DETACH DELETE n')
   })

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -59,6 +59,10 @@ import {
 } from 'shared/modules/frames/framesDuck'
 import { DetailsPane } from './PropertiesPanelContent/DetailsPane'
 import OverviewPane from './PropertiesPanelContent/OverviewPane'
+import {
+  commandSources,
+  executeCommand
+} from 'shared/modules/commands/commandsDuck'
 
 type VisualizationState = {
   updated: number
@@ -426,6 +430,11 @@ LIMIT ${maxNewNeighbours}`
           }
         }
       )
+
+      const cmd = 'MATCH (n) RETURN n LIMIT 25'
+
+      const action = executeCommand(cmd, { source: commandSources.rerunFrame })
+      this.props.bus.send(action.type, action)
     }
   }
 

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -430,7 +430,6 @@ LIMIT ${maxNewNeighbours}`
       )
 
       const cmd = 'MATCH (n) RETURN n;'
-
       const action = executeCommand(cmd, { source: commandSources.rerunFrame })
       this.props.bus.send(action.type, action)
     }

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -403,9 +403,7 @@ LIMIT ${maxNewNeighbours}`
 
     if (event == NODE_ON_CANVAS_CREATE) {
       if (properties == null) {
-        throw new Error(
-          'A property map with name, and labels keys are required'
-        )
+        throw new Error('NODE_ON_CANVAS_CREATE: properties map is required')
       }
 
       const name = properties['name']
@@ -431,7 +429,7 @@ LIMIT ${maxNewNeighbours}`
         }
       )
 
-      const cmd = 'MATCH (n) RETURN n LIMIT 25'
+      const cmd = 'MATCH (n) RETURN n;'
 
       const action = executeCommand(cmd, { source: commandSources.rerunFrame })
       this.props.bus.send(action.type, action)

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/GraphEventHandlerModel.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/GraphEventHandlerModel.ts
@@ -244,27 +244,6 @@ export class GraphEventHandlerModel {
   }
 
   onCanvasDblClicked(): void {
-    const transientId: string =
-      'transient-' + Math.random().toString(36).slice(2)
-
-    this.graph.addNodes([
-      new NodeModel(
-        transientId,
-        ['Undefined'],
-        {
-          name: 'New Node',
-          description: 'New Node'
-        },
-        {
-          name: 'string',
-          description: 'string'
-        },
-        transientId
-      )
-    ])
-    this.visualization.update({ updateNodes: true, updateRelationships: true })
-    this.graphModelChanged()
-
     this.onGraphInteraction(NODE_ON_CANVAS_CREATE, {
       name: 'New Node',
       description: 'New Node',

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/GraphEventHandlerModel.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/GraphEventHandlerModel.ts
@@ -40,7 +40,6 @@ export type GraphInteraction =
   | 'NODE_EXPAND'
   | 'NODE_UNPINNED'
   | 'NODE_DISMISSED'
-  | 'NODE_ON_CANVAS_CREATE'
   | typeof NODE_ON_CANVAS_CREATE
   | typeof NODE_PROP_UPDATE
   | typeof NODE_LABEL_UPDATE

--- a/src/neo4j-arc/package.json
+++ b/src/neo4j-arc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-devtools-arc",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "main": "dist/neo4j-arc.js",
   "author": "Neo4j Inc.",
   "license": "GPL-3.0",


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

Changelog
---------

### Added

### Changed

- https://github.com/QubitPi/neo4j-browser/pull/22 raised a question: if node/rel id is transient, then on-canvas relationship creation won't work because the source and target ID needs to be persisted ID's which is not possible with transient ID still exist on canvas. We must update DB first and trigger a re-rendering. In the same time therefore, https://github.com/QubitPi/neo4j-browser/pull/7 is not the optimal way of implementing double-clicking

  - We will trigger a new frame for re-rendering

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
* [x] (neo4j-arc) Manually bump version
