### PR TITLE
On-canvas relationship creation is done by sending message only

### DIFF
--- a/docs/modules/ROOT/pages/operations/on-canvas-operations.adoc
+++ b/docs/modules/ROOT/pages/operations/on-canvas-operations.adoc
@@ -28,3 +28,8 @@ image:modifying-node-properties-example.png[width=600]
 Similary, we can modify node label:
 
 image:modifying-node-label-example.png[width=600]
+
+== Creating On-Canvas Relationships
+
+Alt-clicking one node, release the alk key, and alt-clicking another node will create a relationship between the two
+ 

--- a/e2e_tests/integration/viz.spec.ts
+++ b/e2e_tests/integration/viz.spec.ts
@@ -270,4 +270,34 @@ describe('Viz rendering', () => {
 
     cy.executeCommand('MATCH (n) DETACH DELETE n')
   })
+
+  it('can create a new relationship by alt-clicking two nodes in sequence', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand('MATCH (n) DETACH DELETE n')
+    cy.executeCommand(`CREATE (s:SourceNode {name: 'sourceNode'}) RETURN s`, {
+      parseSpecialCharSequences: false
+    })
+      .executeCommand(`CREATE (t:TargetNode {name: 'targetNode'}) RETURN t`, {
+        parseSpecialCharSequences: false
+      })
+      .executeCommand(`MATCH (n) RETURN n`, {
+        parseSpecialCharSequences: false
+      })
+
+    cy.wait(3000)
+
+    cy.get(`[aria-label^="graph-node"]`)
+      .each($el => {
+        cy.wrap($el).rightclick({
+          altKey: true,
+          metaKey: true,
+          shiftKey: true,
+          ctrlKey: true,
+          multiple: true,
+          force: true
+        })
+      })
+      .get('.relationships')
+      .should('exist')
+  })
 })

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -399,6 +399,10 @@ LIMIT ${maxNewNeighbours}`
           }
         }
       )
+
+      const cmd = 'MATCH (n) RETURN n;'
+      const action = executeCommand(cmd, { source: commandSources.rerunFrame })
+      this.props.bus.send(action.type, action)
     }
 
     if (event == NODE_ON_CANVAS_CREATE) {

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/GraphEventHandlerModel.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/GraphEventHandlerModel.ts
@@ -276,28 +276,8 @@ export class GraphEventHandlerModel {
     ) {
       this.altCreatedRelTargetNode = node
 
-      const transientId: string =
-        'transient-' + Math.random().toString(36).slice(2)
-
-      const altCreatedRel: RelationshipModel = new RelationshipModel(
-        transientId,
-        this.altCreatedRelSourceNode,
-        this.altCreatedRelTargetNode,
-        transientId,
-        { name: 'new link' },
-        { name: 'string' },
-        transientId
-      )
-
-      this.graph.addRelationships([altCreatedRel])
-      this.visualization.update({
-        updateNodes: true,
-        updateRelationships: true
-      })
-      this.graphModelChanged()
-
       this.onGraphInteraction(REL_ON_CANVAS_CREATE, {
-        type: transientId,
+        type: Math.random().toString(36).slice(2),
         sourceNodeId: this.altCreatedRelSourceNode.id,
         targetNodeId: this.altCreatedRelTargetNode.id
       })

--- a/src/neo4j-arc/package.json
+++ b/src/neo4j-arc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-devtools-arc",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "main": "dist/neo4j-arc.js",
   "author": "Neo4j Inc.",
   "license": "GPL-3.0",


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

Changelog
---------

### Added

### Changed

- Inspired by https://github.com/QubitPi/neo4j-browser/pull/26, creating on-canvas relationship is down by suber bus as well

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
* [x] (neo4j-arc) Manually bump version

Reference
---------

- [Is being covered by another element Cypress](https://stackoverflow.com/a/64253473)
- [Getting coordinates of an element](https://github.com/cypress-io/cypress/issues/4632#issuecomment-507839401)
- [How can I get an aria label from React-Calendar using Cypress](https://stackoverflow.com/a/66893951)
- [Select element with class name that starts with using Cypress](https://stackoverflow.com/a/59849612)